### PR TITLE
debian: update /etc/apt/sources.list since "stable" is no longer buster

### DIFF
--- a/Imagefile.debianBuster
+++ b/Imagefile.debianBuster
@@ -4,6 +4,11 @@ PARTITION 1 FORMAT xfs MOUNT /
 
 ADD debian-buster.tar.xz /
 
+RUN > /etc/apt/sources.list; \
+    echo "deb http://deb.debian.org/debian buster main"                       >> /etc/apt/sources.list; \
+    echo "deb http://security.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list; \
+    echo "deb http://deb.debian.org/debian buster-updates main"               >> /etc/apt/sources.list
+
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
        linux-image-amd64 grub2 init systemd \


### PR DESCRIPTION
With the recent debian release, "stable" no longer pointers to "buster"
and the security update has slightly changed.

This revision rewrites sources.list with the "buster" ones